### PR TITLE
Bug fix: use fixed size addr for backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Sync a Celestia light node running on the Arabica testnet
 1. Copy the JWT and and save it in main.rs as `const CELESTIA_NODE_AUTH_TOKEN`. Be careful to paste the entire JWT - it may wrap across several lines in your terminal.
 1. Wait a few minutes for your Celestia node to sync. It needs to have reached at least block `293681` before the demo can run properly.
 
-Once your Celestia node is up and running, simply `cargo run` to test out the prototype.
+Once your Celestia node is up and running, simply `cargo +nightly run` to test out the prototype.
 
 ## What is it?
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,59 @@
+use anyhow::bail;
+use sov_modules_api::{
+    mocks::{MockPublicKey, MockSignature},
+    AddressTrait, Context, Spec,
+};
+use sov_state::{mocks::MockStorageSpec, ProverStorage};
+use sovereign_sdk::core::types::ArrayWitness;
+
+/// Context for the demo rollup.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DemoContext {
+    pub sender: Address,
+}
+
+impl Spec for DemoContext {
+    type Address = Address;
+    type Storage = ProverStorage<MockStorageSpec>;
+    type Hasher = sha2::Sha256;
+    type PublicKey = MockPublicKey;
+    type Signature = MockSignature;
+    type Witness = ArrayWitness;
+}
+
+impl Context for DemoContext {
+    fn sender(&self) -> &Self::Address {
+        &self.sender
+    }
+
+    fn new(sender: Self::Address) -> Self {
+        Self { sender }
+    }
+}
+
+impl AddressTrait for Address {}
+
+/// Default implementation of AddressTrait for the module system
+#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone, Eq)]
+pub struct Address {
+    addr: [u8; 32],
+}
+
+impl<'a> TryFrom<&'a [u8]> for Address {
+    type Error = anyhow::Error;
+
+    fn try_from(addr: &'a [u8]) -> Result<Self, Self::Error> {
+        if addr.len() != 32 {
+            bail!("Address must be 32 bytes long");
+        }
+        let mut addr_bytes = [0u8; 32];
+        addr_bytes.copy_from_slice(&addr);
+        Ok(Self { addr: addr_bytes })
+    }
+}
+
+impl AsRef<[u8]> for Address {
+    fn as_ref(&self) -> &[u8] {
+        self.addr.as_ref()
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,14 +1,14 @@
-use sov_modules_api::{mocks::MockContext, DispatchQuery};
+use sov_modules_api::DispatchQuery;
 use sov_state::{mocks::MockStorageSpec, ProverStorage, WorkingSet};
 
-use crate::runtime::Runtime;
+use crate::{context::DemoContext, runtime::Runtime};
 
 pub(crate) fn run_query(
-    runtime: &mut Runtime<MockContext>,
+    runtime: &mut Runtime<DemoContext>,
     query: Vec<u8>,
     storage: ProverStorage<MockStorageSpec>,
 ) -> String {
-    let module = Runtime::<MockContext>::decode_query(&query).unwrap();
+    let module = Runtime::<DemoContext>::decode_query(&query).unwrap();
     let query_response = runtime.dispatch_query(module, &mut WorkingSet::new(storage));
 
     String::from_utf8(query_response.response).unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ mod tx_verifier;
 
 type C = DemoContext;
 type DemoApp = Demo<C, DemoAppTxVerifier<C>, Runtime<C>, DemoAppTxHooks<C>>;
-const CELESTIA_NODE_AUTH_TOKEN: &'static str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.nHzh7kWvC3puCYgcMJRuNlMudwf6xGagETNdQyRQQ_s";
+const CELESTIA_NODE_AUTH_TOKEN: &'static str = "";
 
 const START_HEIGHT: u64 = HEIGHT_OF_FIRST_TXS - 5;
 // I sent 8 demo election transactions at height 293686, generated using the demo app data generator

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use batch::Batch;
+use context::DemoContext;
 use jsonrpsee::http_client::HeaderMap;
 use jupiter::{
     da_app::{CelestiaApp, TmHash},
     da_service::{CelestiaService, FilteredCelestiaBlock},
 };
 use sha2::{Digest, Sha256};
-use sov_modules_api::mocks::MockContext;
 use sov_state::ProverStorage;
 use sovereign_db::{
     ledger_db::{LedgerDB, SlotCommitBuilder},
@@ -29,6 +29,7 @@ use crate::{
     data_generation::QueryGenerator, helpers::run_query, runtime::Runtime, tx_hooks::DemoAppTxHooks,
 };
 mod batch;
+mod context;
 mod data_generation;
 mod helpers;
 mod runtime;
@@ -36,9 +37,9 @@ mod stf;
 mod tx_hooks;
 mod tx_verifier;
 
-type C = MockContext;
+type C = DemoContext;
 type DemoApp = Demo<C, DemoAppTxVerifier<C>, Runtime<C>, DemoAppTxHooks<C>>;
-const CELESTIA_NODE_AUTH_TOKEN: &'static str = "";
+const CELESTIA_NODE_AUTH_TOKEN: &'static str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.nHzh7kWvC3puCYgcMJRuNlMudwf6xGagETNdQyRQQ_s";
 
 const START_HEIGHT: u64 = HEIGHT_OF_FIRST_TXS - 5;
 // I sent 8 demo election transactions at height 293686, generated using the demo app data generator
@@ -70,7 +71,7 @@ const DATA_DIR_LOCATION: &'static str = "demo_data";
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let subscriber = tracing_subscriber::fmt()
-        .with_max_level(Level::WARN)
+        .with_max_level(Level::INFO)
         .finish();
     tracing::subscriber::set_global_default(subscriber)
         .map_err(|_err| eprintln!("Unable to set global default subscriber"))
@@ -97,7 +98,6 @@ async fn main() -> Result<(), anyhow::Error> {
     }
     let last_slot_processed_before_shutdown = item_numbers.slot_number - 1;
 
-    dbg!(&item_numbers);
     println!("Beginning sync from da slot {}...", START_HEIGHT);
     for i in 0.. {
         let height = START_HEIGHT + i;


### PR DESCRIPTION
We recently updated the default address type in sov-modules to have a dynamic size. This changes the borsh encoding, which causes a hard-fork on the demo rollup. To keep backwards compatibility, implement fixed size addresses in the demo. 